### PR TITLE
Fix linter issues

### DIFF
--- a/src/app/legezt-pdf-ai/page.tsx
+++ b/src/app/legezt-pdf-ai/page.tsx
@@ -13,10 +13,8 @@ import {
   Shield,
   Brain,
   CheckCircle,
-  X,
   MessageSquare,
   Trash2,
-  Download,
   Globe,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -33,6 +31,11 @@ import {
 } from "@/components/ui/dialog";
 import { ChatInterface } from "./components/ChatInterface";
 
+interface ChatMessage {
+  role: "user" | "bot";
+  text: string;
+}
+
 interface PDFFile {
   id: string;
   file: File;
@@ -44,7 +47,7 @@ interface PDFFile {
   summary?: string;
   isProcessing?: boolean;
   isUploaded: boolean;
-  chatHistory?: any[];
+  chatHistory?: ChatMessage[];
 }
 
 // Global storage key
@@ -70,9 +73,10 @@ export default function LegeztPDFAIPage() {
     const savedPDFs = localStorage.getItem(STORAGE_KEY);
     if (savedPDFs) {
       try {
-        const parsedPDFs = JSON.parse(savedPDFs);
+        type StoredPDF = Omit<PDFFile, "file">;
+        const parsedPDFs = JSON.parse(savedPDFs) as StoredPDF[];
         setUploadedPDFs(
-          parsedPDFs.map((pdf: any) => ({
+          parsedPDFs.map((pdf) => ({
             ...pdf,
             file: new File([], pdf.name, {
               type: "application/pdf",

--- a/src/app/legezttube/VideoPlayer.tsx
+++ b/src/app/legezttube/VideoPlayer.tsx
@@ -9,12 +9,10 @@ import {
   Share2, RotateCcw, RotateCw
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
 import { Slider } from '@/components/ui/slider';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Separator } from '@/components/ui/separator';
 import Image from 'next/image';
-import type { videoFormat } from 'ytdl-core';
 
 interface VideoPlayerInfo {
     title: string;

--- a/src/app/legezttube/page.tsx
+++ b/src/app/legezttube/page.tsx
@@ -1,13 +1,12 @@
 
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { 
   Search, Clock, Eye, Play
 } from 'lucide-react';
 import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { getVideoInfo, SearchedVideoInfo } from './actions';
 import Image from 'next/image';


### PR DESCRIPTION
## Summary
- clean unused imports in video player and LegeztTube page
- define a `ChatMessage` type for PDF AI assistant
- properly type stored PDFs when loading from localStorage

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687e015f47088321b01d1a8041cb5aec